### PR TITLE
Fix nested paths on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ module.exports = function(opts) {
     };
 
     function fetch(p) {
-      p = path.dirname('/' + p);
+      p = path.dirname('/' + p).replace(/\\/g,"/");
 
       if (fileTree.path[p]) {
         return fileTree.path[p];


### PR DESCRIPTION
On Windows, `dirname` returns nested paths with a `\\` separator, but the rest of the code expects all paths to be using `/`. Without this fix, nested sub-paths get put as children of the top-level path, with a name like `first_level_child\\second_level_child`.